### PR TITLE
eh: tags parsing

### DIFF
--- a/ehentai.js
+++ b/ehentai.js
@@ -606,7 +606,12 @@ class Ehentai extends ComicSource {
             for(let tr of document.querySelectorAll("div#taglist > table > tbody > tr")) {
                 tags.set(
                     tr.children[0].text.substring(0, tr.children[0].text.length - 1),
-                    tr.children[1].children.map((e) => e.children[0].text)
+                    tr.children[1].children.map((e) =>
+                        e.children[0]
+                        .attributes["onclick"]
+                        .split(":")[1]
+                        .split("'")[0]
+                    )
                 )
             }
 


### PR DESCRIPTION
Ehentai 网页 点击 tag 时实际使用的参数在 onclick 里，
大部分情况下与 text 相同，少数不同的会导致 app 翻译失败，搜索出偏差。
![image](https://github.com/user-attachments/assets/34010f74-5e5d-42a1-8bd0-e6e27d3eaefc)
含有 '|' 的 tag 很多都有这个问题。