### PR TITLE
优化拷贝漫画检索

### DIFF
--- a/copy_manga.js
+++ b/copy_manga.js
@@ -231,7 +231,7 @@ class CopyManga extends ComicSource {
                 author = keyword.substring("作者:".length).trim();
             }
             // 通过onClickTag传入时有"作者:"前缀，处理这种情况
-            if (author & author in this.author_path_word_dict){
+            if (author && author in this.author_path_word_dict){
                 let path_word = encodeURIComponent(this.author_path_word_dict[author]);
                 var res = await Network.get(
                     `https://api.copymanga.tv/api/v3/comics?limit=21&offset=${(page - 1) * 21}&ordering=-datetime_updated&author=${path_word}&platform=3`,
@@ -240,7 +240,10 @@ class CopyManga extends ComicSource {
             }
             // 一般的搜索情况
             else{
-                q_type = options[0];
+                let q_type = "";
+                if(options && options[0]){
+                    q_type = options[0];
+                }
                 keyword = encodeURIComponent(keyword)
                 var res = await Network.get(
                     `https://api.copymanga.tv/api/v3/search/comic?limit=21&offset=${(page - 1) * 21}&q=${keyword}&q_type=${q_type}&platform=3`,

--- a/copy_manga.js
+++ b/copy_manga.js
@@ -460,7 +460,7 @@ class CopyManga extends ComicSource {
             // 储存author对应的path_word
             comicData.author.forEach(e=>(this.author_path_word_dict[e.name] = e.path_word));
             let tags = comicData.theme.map(e => e?.name).filter(name => name !== undefined && name !== null);
-            let updateTime = comicData.datetime_updated;
+            let updateTime = comicData.datetime_updated ? comicData.datetime_updated : "";
             let description = comicData.brief;
 
 

--- a/copy_manga.js
+++ b/copy_manga.js
@@ -137,11 +137,11 @@ class CopyManga extends ComicSource {
             {
                 name: "主题",
                 type: "fixed",
-                categories: ["全部", "爱情", "欢乐向", "冒险", "奇幻", "百合", "校园", "科幻", "东方", "耽美", "生活", "格斗", "轻小说", "悬疑",
-                    "其它", "神鬼", "职场", "TL", "萌系", "治愈", "长条", "四格", "节操", "伪娘", "性转换", "异世界"],
+                categories: ["全部", "愛情", "歡樂向", "冒險", "奇幻", "百合", "校园", "科幻", "東方", "耽美", "生活", "格鬥", "轻小说", "悬疑",
+                    "其他", "神鬼", "职场", "TL", "萌系", "治愈", "長條", "四格", "节操", "伪娘", "性转换", "AA", "异世界"],
                 itemType: "category",
                 categoryParams: ["", "aiqing", "huanlexiang", "maoxian", "qihuan", "baihe", "xiaoyuan", "kehuan", "dongfang", "danmei", "shenghuo", "gedou", "qingxiaoshuo", "xuanyi",
-                    "qita", "shengui", "zhichang", "teenslove", "mengxi", "zhiyu", "changtiao", "sige", "jiecao", "weiniang", "xingzhuanhuan", "yishijie"]
+                    "qita", "shengui", "zhichang", "teenslove", "mengxi", "zhiyu", "changtiao", "sige", "jiecao", "weiniang", "xingzhuanhuan", "aa", "yishijie"]
             }
         ]
     }

--- a/copy_manga.js
+++ b/copy_manga.js
@@ -213,10 +213,10 @@ class CopyManga extends ComicSource {
             },
             {
                 options: [
-                    "*datetime_updated-时间正序",
-                    "datetime_updated-时间倒序",
-                    "*popular-热度正序",
-                    "popular-热度倒序",
+                    "*datetime_updated-时间倒序",
+                    "datetime_updated-时间正序",
+                    "*popular-热度倒序",
+                    "popular-热度正序",
                 ],
                 notShowWhen: null,
                 showWhen: null

--- a/copy_manga.js
+++ b/copy_manga.js
@@ -137,11 +137,23 @@ class CopyManga extends ComicSource {
             {
                 name: "主题",
                 type: "fixed",
-                categories: ["全部", "愛情", "歡樂向", "冒險", "奇幻", "百合", "校园", "科幻", "東方", "耽美", "生活", "格鬥", "轻小说", "悬疑",
-                    "其他", "神鬼", "职场", "TL", "萌系", "治愈", "長條", "四格", "节操", "伪娘", "性转换", "AA", "异世界"],
-                itemType: "category",
-                categoryParams: ["", "aiqing", "huanlexiang", "maoxian", "qihuan", "baihe", "xiaoyuan", "kehuan", "dongfang", "danmei", "shenghuo", "gedou", "qingxiaoshuo", "xuanyi",
-                    "qita", "shengui", "zhichang", "teenslove", "mengxi", "zhiyu", "changtiao", "sige", "jiecao", "weiniang", "xingzhuanhuan", "aa", "yishijie"]
+                categories: [ "全部",
+                    "愛情", "歡樂向", "冒險", "奇幻", "百合", "校园", "科幻", "東方", "耽美", "生活", 
+                    "格鬥", "轻小说", "悬疑", "其他", "神鬼", "职场", "TL", "萌系", "治愈", "長條", 
+                    "四格", "节操", "舰娘", "竞技", "搞笑", "伪娘", "热血", "励志", "性转换", "彩色", 
+                    "後宮", "美食", "侦探", "AA", "音乐舞蹈", "魔幻", "战争", "历史", "异世界", "惊悚", 
+                    "机战", "都市", "穿越", "恐怖", "C100", "重生", "C99", "C101", "C97", "C96", "生存", 
+                    "宅系", "武侠", "C98", "C95", "FATE", "转生", "無修正", "仙侠", "LoveLive"
+                ],
+                categoryParams: [ "",
+                    "aiqing", "huanlexiang", "maoxian", "qihuan", "baihe", "xiaoyuan", "kehuan", "dongfang", "danmei", "shenghuo",
+                    "gedou", "qingxiaoshuo", "xuanyi", "qita", "shengui", "zhichang", "teenslove", "mengxi", "zhiyu", "changtiao",
+                    "sige", "jiecao", "jianniang", "jingji", "gaoxiao", "weiniang", "rexue", "lizhi", "xingzhuanhuan", "COLOR",
+                    "hougong", "meishi", "zhentan", "aa", "yinyuewudao", "mohuan", "zhanzheng", "lishi", "yishijie", "jingsong", 
+                    "jizhan", "dushi", "chuanyue", "kongbu", "comiket100", "chongsheng", "comiket99", "comiket101", "comiket97", "comiket96", "shengcun",
+                    "zhaixi", "wuxia", "C98", "comiket95", "fate", "zhuansheng", "Uncensored", "xianxia", "loveLive"
+                ],
+                itemType: "category"
             }
         ]
     }

--- a/copy_manga.js
+++ b/copy_manga.js
@@ -459,7 +459,7 @@ class CopyManga extends ComicSource {
             }
             // 储存author对应的path_word
             comicData.author.forEach(e=>(this.author_path_word_dict[e.name] = e.path_word));
-            let tags = comicData.theme.map(e => e.name);
+            let tags = comicData.theme.map(e => e?.name).filter(name => name !== undefined && name !== null);
             let updateTime = comicData.datetime_updated;
             let description = comicData.brief;
 


### PR DESCRIPTION
优化：
Search界面：增加搜索选项，可以搜索“全部/名称/作者/汉化组”

漫画信息界面：

* 点击作者Tags时，跳转到作者页。**!!!使用的是自己创建的this.author_path_word_dict来储存author中文名对应的作者页需要的path_word（最大长度100）。因为这个跳转用的是search，如果访问了一个漫画，那么search界面里用 "作者:XXX" 来搜索，搜索出来的也是作者页（只要那个作者还储存在this.author_path_word_dict中）** **因为onClickTag的search目前只能把keyword传过去，所以那边也只能解析keyword来做出行为**

* 点击标签Tags时，跳转到对应categories页。
目前标签的Tags是繁体，categories是简体。所以不能直接用Categories和categoryParams来让标签Tags直接对应到param上。为了省事，把categories统一成拷贝上的繁体了。
- 顺便把所有拷贝的categories都补充上去了

~Bugfix: category里的ordering options 时间/热度 的正序和倒序 反了~
没反，我把正序倒序理解错了。倒序才是latest。

~Bug notfix: 一些古早的书（eg《白衣恋爱实验社》）打开会报错“type 'Null' is not a subtype of type 'String'”。这不是我的代码造成的问题，因为老代码打开这个也会报错。~
Bugfix: 修复因为更新日期或tags为null，而导致打开漫画时的报错。