### PR TITLE
copymanga: 评论楼层中增加 `回复者👉被回复者` 的显示。发现了一个评论区回复的问题（修不好）。

### DIFF
--- a/copy_manga.js
+++ b/copy_manga.js
@@ -690,10 +690,13 @@ class CopyManga extends ComicSource {
             }
             let res = await Network.get(
                 url,
-                this.headers,
+                // this.headers, // 在发送评论后，使用这个header获得的评论列表没有刚发的评论（而不使用header时可以获取完整的评论列表）。所以先注释掉。TODO: FIX THIS ISSUE
             );
 
             if (res.status !== 200) {
+                if(res.status === 210){
+                    throw "210：注冊用戶一天可以發5條評論"
+                }
                 throw `Invalid status code: ${res.status}`;
             }
 

--- a/copy_manga.js
+++ b/copy_manga.js
@@ -231,7 +231,7 @@ class CopyManga extends ComicSource {
                 author = keyword.substring("作者:".length).trim();
             }
             // 通过onClickTag传入时有"作者:"前缀，处理这种情况
-            if (author & author in this.author_path_word_dict){
+            if (author && author in this.author_path_word_dict){
                 let path_word = encodeURIComponent(this.author_path_word_dict[author]);
                 var res = await Network.get(
                     `https://api.copymanga.tv/api/v3/comics?limit=21&offset=${(page - 1) * 21}&ordering=-datetime_updated&author=${path_word}&platform=3`,
@@ -240,7 +240,10 @@ class CopyManga extends ComicSource {
             }
             // 一般的搜索情况
             else{
-                q_type = options[0];
+                let q_type = "";
+                if(options && options[0]){
+                    q_type = options[0];
+                }
                 keyword = encodeURIComponent(keyword)
                 var res = await Network.get(
                     `https://api.copymanga.tv/api/v3/search/comic?limit=21&offset=${(page - 1) * 21}&q=${keyword}&q_type=${q_type}&platform=3`,

--- a/copy_manga.js
+++ b/copy_manga.js
@@ -690,7 +690,7 @@ class CopyManga extends ComicSource {
             }
             let res = await Network.get(
                 url,
-                // this.headers, // 在发送评论后，使用这个header获得的评论列表没有刚发的评论（而不使用header时可以获取完整的评论列表）。所以先注释掉。TODO: FIX THIS ISSUE
+                this.headers,
             );
 
             if (res.status !== 200) {

--- a/copy_manga.js
+++ b/copy_manga.js
@@ -257,8 +257,9 @@ class CopyManga extends ComicSource {
                     q_type = options[0];
                 }
                 keyword = encodeURIComponent(keyword)
+                search_url = this.loadSetting('search_api') == "webAPI" ? "https://www.copymanga.tv/api/kb/web/searchbc/comics" : "https://api.copymanga.tv/api/v3/search/comic"
                 var res = await Network.get(
-                    `https://${this.loadSetting('search_url')}?limit=21&offset=${(page - 1) * 21}&q=${keyword}&q_type=${q_type}&platform=3`,
+                    `${search_url}?limit=21&offset=${(page - 1) * 21}&q=${keyword}&q_type=${q_type}&platform=3`,
                     this.headers
                 )
             }
@@ -588,7 +589,7 @@ class CopyManga extends ComicSource {
     }
 
     settings = {
-        search_url: {
+        search_api: {
             // title
             title: "搜索方式",
             // type: input, select, switch
@@ -596,15 +597,15 @@ class CopyManga extends ComicSource {
             // options
             options: [
                 {
-                    value: 'api.copymanga.tv/api/v3/search/comic',
+                    value: 'baseAPI',
                     text: '基础API'
                 },
                 {
-                    value: 'www.copymanga.tv/api/kb/web/searchbc/comics',
+                    value: 'webAPI',
                     text: '网页端API（可搜版权作）'
                 },
             ],
-            default: 'www.copymanga.tv/api/kb/web/searchbc/comics',
+            default: 'webAPI',
         },
     }
 }

--- a/copy_manga.js
+++ b/copy_manga.js
@@ -460,7 +460,7 @@ class CopyManga extends ComicSource {
             // 储存author对应的path_word
             comicData.author.forEach(e=>(this.author_path_word_dict[e.name] = e.path_word));
             let tags = comicData.theme.map(e => e?.name).filter(name => name !== undefined && name !== null);
-            let updateTime = comicData.datetime_updated;
+            let updateTime = comicData.datetime_updated ? comicData.datetime_updated : "";
             let description = comicData.brief;
 
 

--- a/copy_manga.js
+++ b/copy_manga.js
@@ -253,19 +253,12 @@ class CopyManga extends ComicSource {
             // 一般的搜索情况
             else{
                 let q_type = "";
-                let base_url = "https://api.copymanga.tv/api/v3/search/comic";
                 if(options && options[0]){
                     q_type = options[0];
                 }
-                if(options && options[1]){
-                    let searchWithWebAPI = JSON.parse(options[1]).length > 0;
-                    if(searchWithWebAPI){
-                        base_url = "https://www.copymanga.tv/api/kb/web/searchbc/comics"
-                    }
-                }
                 keyword = encodeURIComponent(keyword)
                 var res = await Network.get(
-                    `${base_url}?limit=21&offset=${(page - 1) * 21}&q=${keyword}&q_type=${q_type}&platform=3`,
+                    `${this.loadSetting('search_url')}?limit=21&offset=${(page - 1) * 21}&q=${keyword}&q_type=${q_type}&platform=3`,
                     this.headers
                 )
             }
@@ -315,13 +308,6 @@ class CopyManga extends ComicSource {
                 ],
                 label: "搜索选项"
             },
-            {
-                type: "multi-select",
-                options: [
-                    "1-使用网页端API（可搜版权作品）"
-                ],
-                default: ["1"]
-            }
         ]
     }
 
@@ -599,5 +585,26 @@ class CopyManga extends ComicSource {
             }
             throw "未支持此类Tag检索"
         }
+    }
+
+    settings = {
+        search_url: {
+            // title
+            title: "搜索方式",
+            // type: input, select, switch
+            type: "select",
+            // options
+            options: [
+                {
+                    value: 'https://api.copymanga.tv/api/v3/search/comic',
+                    text: '基础API'
+                },
+                {
+                    value: 'https://www.copymanga.tv/api/kb/web/searchbc/comics',
+                    text: '网页端API（可搜版权作）'
+                },
+            ],
+            default: 'https://www.copymanga.tv/api/kb/web/searchbc/comics',
+        },
     }
 }

--- a/copy_manga.js
+++ b/copy_manga.js
@@ -137,11 +137,11 @@ class CopyManga extends ComicSource {
             {
                 name: "主题",
                 type: "fixed",
-                categories: ["全部", "爱情", "欢乐向", "冒险", "奇幻", "百合", "校园", "科幻", "东方", "耽美", "生活", "格斗", "轻小说", "悬疑",
-                    "其它", "神鬼", "职场", "TL", "萌系", "治愈", "长条", "四格", "节操", "伪娘", "性转换", "异世界"],
+                categories: ["全部", "愛情", "歡樂向", "冒險", "奇幻", "百合", "校园", "科幻", "東方", "耽美", "生活", "格鬥", "轻小说", "悬疑",
+                    "其他", "神鬼", "职场", "TL", "萌系", "治愈", "長條", "四格", "节操", "伪娘", "性转换", "AA", "异世界"],
                 itemType: "category",
                 categoryParams: ["", "aiqing", "huanlexiang", "maoxian", "qihuan", "baihe", "xiaoyuan", "kehuan", "dongfang", "danmei", "shenghuo", "gedou", "qingxiaoshuo", "xuanyi",
-                    "qita", "shengui", "zhichang", "teenslove", "mengxi", "zhiyu", "changtiao", "sige", "jiecao", "weiniang", "xingzhuanhuan", "yishijie"]
+                    "qita", "shengui", "zhichang", "teenslove", "mengxi", "zhiyu", "changtiao", "sige", "jiecao", "weiniang", "xingzhuanhuan", "aa", "yishijie"]
             }
         ]
     }

--- a/copy_manga.js
+++ b/copy_manga.js
@@ -213,10 +213,10 @@ class CopyManga extends ComicSource {
             },
             {
                 options: [
-                    "*datetime_updated-时间正序",
-                    "datetime_updated-时间倒序",
-                    "*popular-热度正序",
-                    "popular-热度倒序",
+                    "*datetime_updated-时间倒序",
+                    "datetime_updated-时间正序",
+                    "*popular-热度倒序",
+                    "popular-热度正序",
                 ],
                 notShowWhen: null,
                 showWhen: null

--- a/copy_manga.js
+++ b/copy_manga.js
@@ -597,15 +597,16 @@ class CopyManga extends ComicSource {
             // options
             options: [
                 {
+                    value: 'webAPI',
+                    text: '网页端API'
+                },
+                {
                     value: 'baseAPI',
                     text: '基础API'
                 },
-                {
-                    value: 'webAPI',
-                    text: '网页端API（可搜版权作）'
-                },
+
             ],
-            default: 'webAPI',
+            default: 'webAPI'
         },
     }
 }

--- a/copy_manga.js
+++ b/copy_manga.js
@@ -137,11 +137,23 @@ class CopyManga extends ComicSource {
             {
                 name: "主题",
                 type: "fixed",
-                categories: ["全部", "愛情", "歡樂向", "冒險", "奇幻", "百合", "校园", "科幻", "東方", "耽美", "生活", "格鬥", "轻小说", "悬疑",
-                    "其他", "神鬼", "职场", "TL", "萌系", "治愈", "長條", "四格", "节操", "伪娘", "性转换", "AA", "异世界"],
-                itemType: "category",
-                categoryParams: ["", "aiqing", "huanlexiang", "maoxian", "qihuan", "baihe", "xiaoyuan", "kehuan", "dongfang", "danmei", "shenghuo", "gedou", "qingxiaoshuo", "xuanyi",
-                    "qita", "shengui", "zhichang", "teenslove", "mengxi", "zhiyu", "changtiao", "sige", "jiecao", "weiniang", "xingzhuanhuan", "aa", "yishijie"]
+                categories: [ "全部",
+                    "愛情", "歡樂向", "冒險", "奇幻", "百合", "校园", "科幻", "東方", "耽美", "生活", 
+                    "格鬥", "轻小说", "悬疑", "其他", "神鬼", "职场", "TL", "萌系", "治愈", "長條", 
+                    "四格", "节操", "舰娘", "竞技", "搞笑", "伪娘", "热血", "励志", "性转换", "彩色", 
+                    "後宮", "美食", "侦探", "AA", "音乐舞蹈", "魔幻", "战争", "历史", "异世界", "惊悚", 
+                    "机战", "都市", "穿越", "恐怖", "C100", "重生", "C99", "C101", "C97", "C96", "生存", 
+                    "宅系", "武侠", "C98", "C95", "FATE", "转生", "無修正", "仙侠", "LoveLive"
+                ],
+                categoryParams: [ "",
+                    "aiqing", "huanlexiang", "maoxian", "qihuan", "baihe", "xiaoyuan", "kehuan", "dongfang", "danmei", "shenghuo",
+                    "gedou", "qingxiaoshuo", "xuanyi", "qita", "shengui", "zhichang", "teenslove", "mengxi", "zhiyu", "changtiao",
+                    "sige", "jiecao", "jianniang", "jingji", "gaoxiao", "weiniang", "rexue", "lizhi", "xingzhuanhuan", "COLOR",
+                    "hougong", "meishi", "zhentan", "aa", "yinyuewudao", "mohuan", "zhanzheng", "lishi", "yishijie", "jingsong", 
+                    "jizhan", "dushi", "chuanyue", "kongbu", "comiket100", "chongsheng", "comiket99", "comiket101", "comiket97", "comiket96", "shengcun",
+                    "zhaixi", "wuxia", "C98", "comiket95", "fate", "zhuansheng", "Uncensored", "xianxia", "loveLive"
+                ],
+                itemType: "category"
             }
         ]
     }

--- a/copy_manga.js
+++ b/copy_manga.js
@@ -257,7 +257,7 @@ class CopyManga extends ComicSource {
                     q_type = options[0];
                 }
                 keyword = encodeURIComponent(keyword)
-                search_url = this.loadSetting('search_api') == "webAPI" ? "https://www.copymanga.tv/api/kb/web/searchbc/comics" : "https://api.copymanga.tv/api/v3/search/comic"
+                let search_url = this.loadSetting('search_api') == "webAPI" ? "https://www.copymanga.tv/api/kb/web/searchbc/comics" : "https://api.copymanga.tv/api/v3/search/comic"
                 var res = await Network.get(
                     `${search_url}?limit=21&offset=${(page - 1) * 21}&q=${keyword}&q_type=${q_type}&platform=3`,
                     this.headers

--- a/copy_manga.js
+++ b/copy_manga.js
@@ -459,7 +459,7 @@ class CopyManga extends ComicSource {
             }
             // 储存author对应的path_word
             comicData.author.forEach(e=>(this.author_path_word_dict[e.name] = e.path_word));
-            let tags = comicData.theme.map(e => e.name);
+            let tags = comicData.theme.map(e => e?.name).filter(name => name !== undefined && name !== null);
             let updateTime = comicData.datetime_updated;
             let description = comicData.brief;
 

--- a/copy_manga.js
+++ b/copy_manga.js
@@ -253,12 +253,19 @@ class CopyManga extends ComicSource {
             // 一般的搜索情况
             else{
                 let q_type = "";
+                let base_url = "https://api.copymanga.tv/api/v3/search/comic";
                 if(options && options[0]){
                     q_type = options[0];
                 }
+                if(options && options[1]){
+                    let searchWithWebAPI = JSON.parse(options[1]).length > 0;
+                    if(searchWithWebAPI){
+                        base_url = "https://www.copymanga.tv/api/kb/web/searchbc/comics"
+                    }
+                }
                 keyword = encodeURIComponent(keyword)
                 var res = await Network.get(
-                    `https://api.copymanga.tv/api/v3/search/comic?limit=21&offset=${(page - 1) * 21}&q=${keyword}&q_type=${q_type}&platform=3`,
+                    `${base_url}?limit=21&offset=${(page - 1) * 21}&q=${keyword}&q_type=${q_type}&platform=3`,
                     this.headers
                 )
             }
@@ -307,6 +314,13 @@ class CopyManga extends ComicSource {
                     "local-汉化组"
                 ],
                 label: "搜索选项"
+            },
+            {
+                type: "multi-select",
+                options: [
+                    "1-使用网页端API（可搜版权作品）"
+                ],
+                default: ["1"]
             }
         ]
     }

--- a/copy_manga.js
+++ b/copy_manga.js
@@ -258,7 +258,7 @@ class CopyManga extends ComicSource {
                 }
                 keyword = encodeURIComponent(keyword)
                 var res = await Network.get(
-                    `${this.loadSetting('search_url')}?limit=21&offset=${(page - 1) * 21}&q=${keyword}&q_type=${q_type}&platform=3`,
+                    `https://${this.loadSetting('search_url')}?limit=21&offset=${(page - 1) * 21}&q=${keyword}&q_type=${q_type}&platform=3`,
                     this.headers
                 )
             }
@@ -596,15 +596,15 @@ class CopyManga extends ComicSource {
             // options
             options: [
                 {
-                    value: 'https://api.copymanga.tv/api/v3/search/comic',
+                    value: 'api.copymanga.tv/api/v3/search/comic',
                     text: '基础API'
                 },
                 {
-                    value: 'https://www.copymanga.tv/api/kb/web/searchbc/comics',
+                    value: 'www.copymanga.tv/api/kb/web/searchbc/comics',
                     text: '网页端API（可搜版权作）'
                 },
             ],
-            default: 'https://www.copymanga.tv/api/kb/web/searchbc/comics',
+            default: 'www.copymanga.tv/api/kb/web/searchbc/comics',
         },
     }
 }

--- a/copy_manga.js
+++ b/copy_manga.js
@@ -704,7 +704,7 @@ class CopyManga extends ComicSource {
             return {
                 comments: data.results.list.map(e => {
                     return {
-                        userName: e.user_name,
+                        userName: replyTo ? `${e.user_name}  👉  ${e.parent_user_name}` : e.user_name, // 拷贝的回复页并没有楼中楼（所有回复都在一个response中），但会显示谁回复了谁。所以加上👉显示。
                         avatar: e.user_avatar,
                         content: e.comment,
                         time: e.create_at,


### PR DESCRIPTION
* 拷贝漫画的一个楼下的回复是在一个response里全部列出，所以不存在楼中楼（即在评论楼中再点击其中一个楼层的回复时，会返回[]）。该reponse里有 每个人的回复对象，所以添加一个显示。

一个response示例：https://api.copymanga.tv/api/v3/comments?comic_id=21beca64-53df-11ee-8f2f-d3d228a76de6&limit=20&offset=0&reply_id=15022&_update=true

大概界面如下：

![img_v3_02jg_785b3b7c-d6b2-45c8-b458-d1f2ed7131cg](https://github.com/user-attachments/assets/84ef919a-5749-45aa-9114-49264e986adc)

* 发现了一个评论区回复的问题（修不好）：使用Venera在评论区回复后，获得的response中没有刚回复的那一项（但是我在浏览器里单独使用那个api获得的response里是完整的）。因为拷贝限制一天只能发送5条评论，所以目前还没查出是什么原因导致的（）
