### PR TITLE
[copy_manga] Remove copyVersion and set defaultCopyVesion to 2.2.9-dev

### DIFF
--- a/copy_manga.js
+++ b/copy_manga.js
@@ -4,7 +4,7 @@ class CopyManga extends ComicSource {
 
     key = "copy_manga"
 
-    version = "1.3.0"
+    version = "1.3.1"
 
     minAppVersion = "1.2.1"
 
@@ -12,7 +12,7 @@ class CopyManga extends ComicSource {
 
     headers = {}
 
-    static defaultCopyVersion = "2.2.9"
+    static defaultCopyVersion = "2.2.9-dev"
 
     static defaultCopyPlatform = "2"
 
@@ -51,7 +51,6 @@ class CopyManga extends ComicSource {
             "User-Agent": "COPY/" + this.copyVersion,
             "Accept": "*/*",
             "Accept-Encoding": "gzip",
-            "source": "copyApp",
             "webp": "1",
             "region": this.copyRegion,
             "version": this.copyVersion,


### PR DESCRIPTION
Experimental results show that for the upgraded CopyManga API, using a non-standard version number (like `2.2.9-dev`) and removing the `source: copyApp` header enables normal functionality.

经实验，拷贝漫画API升级后，仅需将版本号设为非标准格式的版本号（如 `2.2.9-dev`），并删除headers里的 `source: copyApp`，即可正常使用。
