### PR TITLE
feat(漫画详情): 爱看漫 添加更新时间字段并重构返回对象

### DIFF
--- a/ikmmh.js
+++ b/ikmmh.js
@@ -388,17 +388,28 @@ class Ikm extends ComicSource {
         );
       let intro = desc?.[1]?.trim().replace(/\s+/g, " ") || "";
 
-      return {
+      // 获取更新日期
+      let fullDateStr = document
+        .querySelector('meta[property="og:cartoon:update_time"]')
+        .attributes["content"]; // "2025-07-18 08:37:02"
+      let date = new Date(fullDateStr);
+      let year = date.getFullYear();
+      let month = String(date.getMonth() + 1).padStart(2, "0"); // 月份从0开始，要加1
+      let day = String(date.getDate()).padStart(2, "0");
+      let updateTime = `${year}-${month}-${day}`;
+      
+      return new ComicDetails({
         title: title.split("~")[0],
         cover: thumb,
         description: intro,
+        updateTime: updateTime,
         tags: {
           作者: [
             document
               .querySelector("div.book-container__author")
               .text.split("作者：")[1],
           ],
-          更新: [document.querySelector("div.update > a > em").text],
+          最新章节: [document.querySelector("div.update > a > em").text],
           标签: document
             .querySelectorAll("div.book-hero__detail > div.tags > a")
             .map((e) => e.text.trim())
@@ -412,7 +423,7 @@ class Ikm extends ComicSource {
             cover: e.querySelector("div.thumb_img").attributes["data-src"],
             id: `${Ikm.baseUrl}${e.querySelector("a").attributes["href"]}`,
           })),
-      };
+      });
     },
     onThumbnailLoad: Ikm.thumbConfig,
     loadEp: async (comicId, epId) => {


### PR DESCRIPTION
从meta标签获取漫画更新时间并格式化为YYYY-MM-DD
将返回对象改为ComicDetails实例，保持数据结构一致性。
使其适配追更功能

<img width="697" height="251" alt="PixPin_2025-07-22_18-57-34" src="https://github.com/user-attachments/assets/a881d6bb-5fc4-4c89-b72b-89ae0f778848" />
