### PR TITLE
修复包子漫画最新话只能App查看的问题(#180)

### DIFF
--- a/baozi.js
+++ b/baozi.js
@@ -5,7 +5,7 @@ class Baozi extends ComicSource {
   // 唯一标识符
   key = "baozi";
 
-  version = "1.1.2";
+  version = "1.1.3";
 
   minAppVersion = "1.0.0";
 
@@ -26,13 +26,14 @@ class Baozi extends ComicSource {
       title: "主域名",
       type: "select",
       options: [
+        { value: "bzmgcn.com" },
         { value: "baozimhcn.com" },
         { value: "webmota.com" },
         { value: "kukuc.co" },
         { value: "twmanga.com" },
         { value: "dinnerku.com" },
       ],
-      default: "baozimhcn.com",
+      default: "bzmgcn.com",
     },
   };
 

--- a/index.json
+++ b/index.json
@@ -15,7 +15,7 @@
         "name": "包子漫画",
         "fileName": "baozi.js",
         "key": "baozi",
-        "version": "1.1.2"
+        "version": "1.1.3"
     },
     {
         "name": "Picacg",


### PR DESCRIPTION
更新前：
![Screenshot_2025-12-13-18-19-46-187_com github wgh](https://github.com/user-attachments/assets/d6595adc-111b-4e8b-bed5-cb7b0ed13940)
更新后：
![Screenshot_2025-12-13-18-18-53-445_com github wgh](https://github.com/user-attachments/assets/84294bb8-c0df-48a0-8d5a-9d586aeee721)
