### PR TITLE
feat(Wnacg): 动态生成域名选项

### DIFF
--- a/index.json
+++ b/index.json
@@ -33,7 +33,7 @@
         "name": "紳士漫畫",
         "fileName": "wnacg.js",
         "key": "wnacg",
-        "version": "1.0.4",
+        "version": "1.0.5",
         "description": "紳士漫畫漫畫源, 不能使用時請嘗試更換URL"
     },
     {

--- a/wnacg.js
+++ b/wnacg.js
@@ -7,7 +7,7 @@ class Wnacg extends ComicSource {
     // unique id of the source
     key = "wnacg"
 
-    version = "1.0.4"
+    version = "1.0.5"
 
     minAppVersion = "1.0.0"
 

--- a/wnacg.js
+++ b/wnacg.js
@@ -126,23 +126,23 @@ class Wnacg extends ComicSource {
 
                 if (domains.length > 0) {
                     title = "Update Success"
-                    message = "New domains:\n\n"
+                    message = "Fetched: \n\n"
                 }
             }
         } catch (e) {
-            // 获取失败，使用内置域名
+            // 获取失败，使用自定义域名
         }
 
         if (domains.length == 0) {
             title = "Update Failed"
-            message = `Using built-in domains:\n\n`
+            message = "Using Custom: \n\n"
             domains = Wnacg.domains
         }
 
         for (let i = 0; i < domains.length; i++) {
-            message = message + `Fetched Domain ${i + 1}: ${domains[i]}\n`
+            message = message + `URL ${i + 1}: ${domains[i]}\n`
         }
-        message = message + `\nTotal: ${domains.length} domain(s)`
+        message = message + `\n Total: ${domains.length} URLs\n\n Re-enter page to refresh`
 
         if (showConfirmDialog) {
             UI.showDialog(

--- a/wnacg.js
+++ b/wnacg.js
@@ -723,35 +723,41 @@ class Wnacg extends ComicSource {
         },
     }
 
-    settings = {
-        refreshDomains: {
-            title: "Refresh Domain List",
-            type: "callback",
-            buttonText: "Refresh",
-            callback: () => this.refreshDomains(true)
-        },
-        refreshDomainsOnStart: {
-            title: "Refresh Domain List on Startup",
-            type: "switch",
-            default: true,
-        },
-        domainSelection: {
-            title: "Domain Selection",
-            type: "select",
-            options: [
-                { value: '0', text: 'Custom Domain' },
-                { value: '1', text: 'Domain 1' },
-                { value: '2', text: 'Domain 2' },
-                { value: '3', text: 'Domain 3' }
-            ],
-            default: "0",
-        },
-        domain0: {
-            title: "Custom Domain",
-            type: "input",
-            validator: String.raw`^(?!:\/\/)(?=.{1,253})([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$`,
-            default: 'wnacg.com',
-        },
+    get settings() {
+        // 动态生成选项，总是保留 Custom Domain (0)，然后根据 Wnacg.domains 数量添加选项
+        let domainOptions = [{ value: '0', text: 'Custom Domain' }]
+        for (let i = 0; i < Wnacg.domains.length; i++) {
+            domainOptions.push({
+                value: String(i + 1),
+                text: Wnacg.domains[i]
+            })
+        }
+
+        return {
+            refreshDomains: {
+                title: "Refresh Domain List",
+                type: "callback",
+                buttonText: "Refresh",
+                callback: () => this.refreshDomains(true)
+            },
+            refreshDomainsOnStart: {
+                title: "Refresh Domain List on Startup",
+                type: "switch",
+                default: true,
+            },
+            domainSelection: {
+                title: "Domain Selection",
+                type: "select",
+                options: domainOptions,
+                default: "0",
+            },
+            domain0: {
+                title: "Custom Domain",
+                type: "input",
+                validator: String.raw`^(?!:\/\/)(?=.{1,253})([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$`,
+                default: 'wnacg.com',
+            },
+        }
     }
 
     translation = {


### PR DESCRIPTION
解决获取到的绅士漫画域名数量与切换域名选项不匹配的问题

首次添加该源或打开应用后快速进入漫画源页面，选项可能还没刷新，需要重新进入源页面刷新选项

需要合并https://github.com/venera-app/venera/pull/836