### PR TITLE
修复(GoDa漫画):章节API 410错误，迁移至v2接口

### DIFF
--- a/goda.js
+++ b/goda.js
@@ -118,7 +118,7 @@ class Goda extends ComicSource {
   // unique id of the source
   key = "goda"
 
-  version = "1.1.0"
+  version = "1.2.0"
 
   minAppVersion = "1.4.0"
 
@@ -134,12 +134,12 @@ class Goda extends ComicSource {
     api: {
       title: "API域名",
       type: "input",
-      default: "api-get-v3.mgsearcher.com"
+      default: "v2.apikk.top"
     },
     image: {
       title: "图片域名",
       type: "input",
-      default: "f40-1-4.g-mh.online"
+      default: "c-nd3-1.6wm.top"
     }
   }
 
@@ -148,7 +148,7 @@ class Goda extends ComicSource {
   }
 
   get apiUrl() {
-    return `https://${this.loadSetting("api")}/api`;
+    return `https://${this.loadSetting("api")}/api/v2`;
   }
 
   get imageUrl() {
@@ -462,7 +462,7 @@ class Goda extends ComicSource {
         throw "无效的章节ID";
       }
       const ids = epId.split("@");
-      const res = await Network.get(`${this.apiUrl}/v2/chapter/getinfo?m=${ids[0]}&c=${ids[1]}`, this.headers);
+      const res = await Network.get(`${this.apiUrl}/chapter/getinfo?m=${ids[0]}&c=${ids[1]}`, this.headers);
       if (res.status !== 200) {
         throw `Invalid status code: ${res.status}`;
       }

--- a/goda.js
+++ b/goda.js
@@ -1,14 +1,12 @@
 /**
- * ChapterImageDecoder - ported from keiyoushi/extensions-source (PR #16898)
+ * 章节图片解码器 — 移植自 keiyoushi/extensions-source (PR #16898)
  *
- * The /api/v2/chapter/getinfo endpoint returns the image list as an obfuscated
- * string instead of a plain array. This reverses the site's client-side decoder
- * back into the original JSON array of images.
+ * /api/v2/chapter/getinfo 接口返回的图片列表是混淆后的字符串，而非普通数组。
+ * 此解码器将该字符串还原为原始 JSON 图片数组。
  *
- * Pipeline: strip "J7r" prefix / "nQ" suffix -> split into 3 parts around the
- * "kD" and "W4s" markers -> reorder to part3+part1+part2 -> reverse every 2nd
- * 7-char block -> map the custom alphabet back to standard base64url -> base64
- * decode -> UTF-8 JSON.
+ * 解码流程：去除 "J7r" 前缀 / "nQ" 后缀 → 按 "kD" 和 "W4s" 标记拆分为 3 段
+ * → 重新排序为 段3+段1+段2 → 每隔一个 7 字符块反转 → 将自定义字母表映射回
+ * 标准 base64url → base64 解码 → UTF-8 JSON。
  */
 const STD = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 const CUSTOM = "_-9876543210abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -18,7 +16,7 @@ const DECODE_MARKER2 = "W4s";
 const DECODE_SUFFIX = "nQ";
 const DECODE_GROUP = 7;
 
-// Precomputed lookup: custom-alphabet char code -> standard base64url char (-1 = invalid)
+// 预计算的查找表：自定义字母表字符码 → 标准 base64url 字符码（-1 表示无效）
 const DECODE_TABLE = new Array(128).fill(-1);
 for (let i = 0; i < CUSTOM.length; i++) {
     DECODE_TABLE[CUSTOM.charCodeAt(i)] = STD.charCodeAt(i);
@@ -48,17 +46,17 @@ function decodeChapterImages(input) {
         throw "未知的章节数据格式";
     }
 
-    // Reorder: part3 + part1 + part2
+    // 重新排序：段3 + 段1 + 段2
     const reordered = part3 + part1 + part2;
 
-    // Unzigzag: reverse every 2nd GROUP-char block
+    // 去锯齿：每隔一个 GROUP 长度的块做反转
     let unzigzagged = "";
     for (let i = 0, block = 0; i < reordered.length; i += DECODE_GROUP, block++) {
         const chunk = reordered.substring(i, Math.min(i + DECODE_GROUP, reordered.length));
         unzigzagged += (block % 2 === 1) ? chunk.split('').reverse().join('') : chunk;
     }
 
-    // Map custom alphabet to standard base64url
+    // 将自定义字母表映射为标准 base64url
     let standard = "";
     for (let i = 0; i < unzigzagged.length; i++) {
         const code = unzigzagged.charCodeAt(i);
@@ -69,15 +67,15 @@ function decodeChapterImages(input) {
         standard += String.fromCharCode(mapped);
     }
 
-    // Base64 decode (pure JS, no atob). Convert base64url to standard base64 first.
+    // Base64 解码（纯 JS 实现，venera 运行时不支持 atob）。先将 base64url 转为标准 base64。
     const standardBase64 = standard.replace(/-/g, '+').replace(/_/g, '/');
     const json = decodeBase64(standardBase64);
     return JSON.parse(json);
 }
 
 /**
- * Pure JavaScript base64 decoder (venera runtime lacks atob).
- * Decodes base64 to byte characters for JSON parsing.
+ * 纯 JavaScript base64 解码器（venera 运行时缺少 atob）。
+ * 将 base64 解码为字节字符，供 JSON 解析使用。
  */
 function decodeBase64(str) {
     const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -110,19 +108,19 @@ function decodeBase64(str) {
 
 /** @type {import('./_venera_.js')} */
 class Goda extends ComicSource {
-  // Note: The fields which are marked as [Optional] should be removed if not used
+  // 注意：标记为 [可选] 的字段如果不使用，应将其删除
 
-  // name of the source
+  // 源名称
   name = "GoDa漫画"
 
-  // unique id of the source
+  // 源唯一标识
   key = "goda"
 
-  version = "1.2.0"
+  version = "1.2.1"
 
   minAppVersion = "1.4.0"
 
-  // update url
+  // 更新地址
   url = "https://cdn.jsdelivr.net/gh/venera-app/venera-configs@main/goda.js"
 
   settings = {
@@ -179,14 +177,14 @@ class Goda extends ComicSource {
     return result;
   }
 
-  // explore page list
+  // 发现页列表
   explore = [
     {
-      // title of the page.
-      // title is used to identify the page, it should be unique
+      // 页面标题
+      // title 用于标识页面，必须唯一
       title: this.name,
 
-      /// multiPartPage or multiPageComicList or mixed
+      /// multiPartPage 或 multiPageComicList 或 mixed
       type: "multiPartPage",
 
       load: async () => {
@@ -220,9 +218,9 @@ class Goda extends ComicSource {
     }
   ]
 
-  // categories
+  // 分类
   category = {
-    /// title of the category page, used to identify the page, it should be unique
+    /// 分类页标题，用于标识页面，必须唯一
     title: this.name,
     parts: [
       {
@@ -318,11 +316,11 @@ class Goda extends ComicSource {
         ],
       }
     ],
-    // enable ranking page
+    // 是否启用排行榜页面
     enableRankingPage: false,
   }
 
-  /// category comic loading related
+  /// 分类漫画加载
   categoryComics = {
     load: async (category, params, options, page) => {
       const res = await Network.get(`${this.baseUrl}${params}/page/${page}`, this.headers);
@@ -343,10 +341,10 @@ class Goda extends ComicSource {
     }
   }
 
-  /// search related
+  /// 搜索相关
   search = {
     load: async (keyword, options, page) => {
-      const res = await Network.get(`${this.baseUrl}/s/${keyword}?page=${page}`);
+      const res = await Network.get(`${this.baseUrl}/s/${keyword}?page=${page}`, this.headers);
       if (res.status !== 200) {
         throw `Invalid status code: ${res.status}`;
       }
@@ -362,11 +360,11 @@ class Goda extends ComicSource {
         maxPage: maxPage
       };
     },
-    // enable tags suggestions
+    // 是否启用标签建议
     enableTagsSuggestions: false,
   }
 
-  /// single comic related
+  /// 单部漫画相关
   comic = {
     onThumbnailLoad: (url) => {
       return {
@@ -374,7 +372,7 @@ class Goda extends ComicSource {
       }
     },
     loadInfo: async (id) => {
-      const res = await Network.get(this.baseUrl + id);
+      const res = await Network.get(this.baseUrl + id, this.headers);
       if (res.status !== 200) {
         throw `Invalid status code: ${res.status}`;
       }
@@ -424,16 +422,24 @@ class Goda extends ComicSource {
         throw "无法获取漫画ID";
       }
 
-      const jsonRes = await Network.get(`${this.apiUrl}/manga/get?mid=${mangaId}&mode=all&t=${Date.now()}`, this.headers);
-      const jsonData = JSON.parse(jsonRes.body);
       const chapters = {};
-      if (jsonData["data"] && jsonData["data"]["chapters"]) {
-        for (let ch of jsonData["data"]["chapters"]) {
-          if (ch["id"] != null && ch["attributes"] && ch["attributes"]["title"] != null) {
-            chapters[`${mangaId}@${ch["id"]}`] = ch["attributes"]["title"];
+      const jsonRes = await Network.get(`${this.apiUrl}/manga/get?mid=${mangaId}&mode=all&t=${Date.now()}`, this.headers);
+      if (jsonRes.status !== 200) {
+        throw `Invalid status code: ${jsonRes.status}`;
+      }
+      try {
+        const jsonData = JSON.parse(jsonRes.body);
+        if (jsonData && jsonData["data"] && jsonData["data"]["chapters"]) {
+          for (let ch of jsonData["data"]["chapters"]) {
+            if (ch["id"] != null && ch["attributes"] && ch["attributes"]["title"] != null) {
+              chapters[`${mangaId}@${ch["id"]}`] = ch["attributes"]["title"];
+            }
           }
         }
+      } catch (e) {
+        throw "章节数据解析失败";
       }
+
       const recommend = [];
       for (let item of document.querySelectorAll("div.cardlist > div.pb-2")) {
         const recLink = item.querySelector("a");
@@ -466,16 +472,30 @@ class Goda extends ComicSource {
       if (res.status !== 200) {
         throw `Invalid status code: ${res.status}`;
       }
-      const jsonData = JSON.parse(res.body);
+      let jsonData;
+      try {
+        jsonData = JSON.parse(res.body);
+      } catch (e) {
+        throw "章节数据解析失败";
+      }
+
+      // 空值安全检查：防止 API 返回异常数据结构导致崩溃
+      if (!jsonData || !jsonData["data"] || !jsonData["data"]["info"]
+          || !jsonData["data"]["info"]["images"]) {
+        throw "章节图片数据为空";
+      }
       const imagesRaw = jsonData["data"]["info"]["images"]["images"];
 
       let imagesList;
       if (typeof imagesRaw === "string") {
-        // v2 API: obfuscated string - decode it back to JSON array
+        // v2 API：混淆字符串 — 解码还原为 JSON 数组
         imagesList = decodeChapterImages(imagesRaw);
-      } else {
-        // v1 API (backward compatibility): array of {url: "...", order: N}
+      } else if (Array.isArray(imagesRaw)) {
+        // v1 API（向后兼容）：{url: "...", order: N} 数组
         imagesList = imagesRaw;
+      } else {
+        // 未知格式的图片数据
+        throw "未知的图片数据格式";
       }
 
       const images = [];
@@ -487,7 +507,7 @@ class Goda extends ComicSource {
       return { images };
     },
 
-    // enable tags translate
+    // 是否启用标签翻译
     enableTagsTranslate: false,
   }
 }

--- a/goda.js
+++ b/goda.js
@@ -1,3 +1,113 @@
+/**
+ * ChapterImageDecoder - ported from keiyoushi/extensions-source (PR #16898)
+ *
+ * The /api/v2/chapter/getinfo endpoint returns the image list as an obfuscated
+ * string instead of a plain array. This reverses the site's client-side decoder
+ * back into the original JSON array of images.
+ *
+ * Pipeline: strip "J7r" prefix / "nQ" suffix -> split into 3 parts around the
+ * "kD" and "W4s" markers -> reorder to part3+part1+part2 -> reverse every 2nd
+ * 7-char block -> map the custom alphabet back to standard base64url -> base64
+ * decode -> UTF-8 JSON.
+ */
+const STD = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+const CUSTOM = "_-9876543210abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const DECODE_PREFIX = "J7r";
+const DECODE_MARKER1 = "kD";
+const DECODE_MARKER2 = "W4s";
+const DECODE_SUFFIX = "nQ";
+const DECODE_GROUP = 7;
+
+// Precomputed lookup: custom-alphabet char code -> standard base64url char (-1 = invalid)
+const DECODE_TABLE = new Array(128).fill(-1);
+for (let i = 0; i < CUSTOM.length; i++) {
+    DECODE_TABLE[CUSTOM.charCodeAt(i)] = STD.charCodeAt(i);
+}
+
+function decodeChapterImages(input) {
+    if (typeof input !== "string" || !input.startsWith(DECODE_PREFIX) || !input.endsWith(DECODE_SUFFIX)) {
+        throw "未知的章节数据格式";
+    }
+    const body = input.substring(DECODE_PREFIX.length, input.length - DECODE_SUFFIX.length);
+    const payloadLen = body.length - DECODE_MARKER1.length - DECODE_MARKER2.length;
+    if (payloadLen <= 0) {
+        throw "未知的章节数据格式";
+    }
+
+    const aLen = Math.floor(payloadLen / 3);
+    const bLen = Math.floor((payloadLen - aLen) / 2);
+    const cLen = payloadLen - aLen - bLen;
+
+    const part1 = body.substring(0, bLen);
+    const marker1 = body.substring(bLen, bLen + DECODE_MARKER1.length);
+    const part2 = body.substring(bLen + DECODE_MARKER1.length, bLen + DECODE_MARKER1.length + cLen);
+    const marker2 = body.substring(bLen + DECODE_MARKER1.length + cLen, bLen + DECODE_MARKER1.length + cLen + DECODE_MARKER2.length);
+    const part3 = body.substring(bLen + DECODE_MARKER1.length + cLen + DECODE_MARKER2.length);
+
+    if (marker1 !== DECODE_MARKER1 || marker2 !== DECODE_MARKER2 || part3.length !== aLen) {
+        throw "未知的章节数据格式";
+    }
+
+    // Reorder: part3 + part1 + part2
+    const reordered = part3 + part1 + part2;
+
+    // Unzigzag: reverse every 2nd GROUP-char block
+    let unzigzagged = "";
+    for (let i = 0, block = 0; i < reordered.length; i += DECODE_GROUP, block++) {
+        const chunk = reordered.substring(i, Math.min(i + DECODE_GROUP, reordered.length));
+        unzigzagged += (block % 2 === 1) ? chunk.split('').reverse().join('') : chunk;
+    }
+
+    // Map custom alphabet to standard base64url
+    let standard = "";
+    for (let i = 0; i < unzigzagged.length; i++) {
+        const code = unzigzagged.charCodeAt(i);
+        const mapped = code < DECODE_TABLE.length ? DECODE_TABLE[code] : -1;
+        if (mapped < 0) {
+            throw "无效的章节数据字符";
+        }
+        standard += String.fromCharCode(mapped);
+    }
+
+    // Base64 decode (pure JS, no atob). Convert base64url to standard base64 first.
+    const standardBase64 = standard.replace(/-/g, '+').replace(/_/g, '/');
+    const json = decodeBase64(standardBase64);
+    return JSON.parse(json);
+}
+
+/**
+ * Pure JavaScript base64 decoder (venera runtime lacks atob).
+ * Decodes base64 to byte characters for JSON parsing.
+ */
+function decodeBase64(str) {
+    const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    str = str.replace(/=+$/, "");
+
+    let result = "";
+    let i = 0;
+    while (i < str.length) {
+        const enc1 = chars.indexOf(str.charAt(i));
+        const enc2 = chars.indexOf(str.charAt(i + 1));
+        const enc3 = str.charAt(i + 2) ? chars.indexOf(str.charAt(i + 2)) : -1;
+        const enc4 = str.charAt(i + 3) ? chars.indexOf(str.charAt(i + 3)) : -1;
+
+        if (enc1 < 0 || enc2 < 0) {
+            throw "Invalid base64 character";
+        }
+
+        result += String.fromCharCode((enc1 << 2) | (enc2 >> 4));
+        if (enc3 >= 0) {
+            result += String.fromCharCode(((enc2 & 15) << 4) | (enc3 >> 2));
+        }
+        if (enc4 >= 0) {
+            result += String.fromCharCode(((enc3 & 3) << 6) | enc4);
+        }
+
+        i += 4;
+    }
+    return result;
+}
+
 /** @type {import('./_venera_.js')} */
 class Goda extends ComicSource {
   // Note: The fields which are marked as [Optional] should be removed if not used
@@ -8,7 +118,7 @@ class Goda extends ComicSource {
   // unique id of the source
   key = "goda"
 
-  version = "1.0.0"
+  version = "1.1.0"
 
   minAppVersion = "1.4.0"
 
@@ -29,7 +139,7 @@ class Goda extends ComicSource {
     image: {
       title: "图片域名",
       type: "input",
-      default: "t40-1-4.g-mh.online"
+      default: "f40-1-4.g-mh.online"
     }
   }
 
@@ -53,14 +163,18 @@ class Goda extends ComicSource {
   }
 
   parseComics(doc) {
-    console.warn(doc)
     const result = [];
     for (let item of doc.querySelectorAll(".pb-2")) {
-      result.push(new Comic({
-        id: item.querySelector("a").attributes["href"],
-        title: item.querySelector("h3").text,
-        cover: item.querySelector("img").attributes["src"]
-      }))
+      const link = item.querySelector("a");
+      const titleEl = item.querySelector("h3");
+      const img = item.querySelector("img");
+      if (link && titleEl && img && link.attributes["href"] && img.attributes["src"]) {
+        result.push(new Comic({
+          id: link.attributes["href"],
+          title: titleEl.text,
+          cover: img.attributes["src"]
+        }));
+      }
     }
     return result;
   }
@@ -265,42 +379,73 @@ class Goda extends ComicSource {
         throw `Invalid status code: ${res.status}`;
       }
       const document = new HtmlDocument(res.body);
-      const title = document.querySelector(".text-xl").text.trim().split("   ")[0]
-      const cover = document.querySelector(".object-cover").attributes["src"];
-      const description = document.querySelector("p.text-medium").text;
+
+      const titleEl = document.querySelector(".text-xl");
+      const title = titleEl ? (titleEl.text || "").trim().split("   ")[0] : "";
+
+      const coverEl = document.querySelector(".object-cover");
+      const cover = (coverEl && coverEl.attributes && coverEl.attributes["src"]) || "";
+
+      const descEl = document.querySelector("p.text-medium");
+      const description = descEl ? (descEl.text || "") : "";
+
       const infos = document.querySelectorAll("div.py-1");
       const tags = { "作者": [], "类型": [], "标签": [] };
-      for (let author of infos[0].querySelectorAll("a > span")) {
-        let author_name = author.text.trim();
-        if (author_name.endsWith(",")) {
-          author_name = author_name.slice(0, -1).trim();
+      if (infos && infos.length >= 3) {
+        if (infos[0]) {
+          for (let author of infos[0].querySelectorAll("a > span")) {
+            let author_name = (author.text || "").trim();
+            if (author_name.endsWith(",")) {
+              author_name = author_name.slice(0, -1).trim();
+            }
+            if (author_name) tags["作者"].push(author_name);
+          }
         }
-        tags["作者"].push(author_name);
-      }
-      for (let category of infos[1].querySelectorAll("a > span")) {
-        let category_name = category.text.trim();
-        if (category_name.endsWith(",")) {
-          category_name = category_name.slice(0, -1).trim();
+        if (infos[1]) {
+          for (let category of infos[1].querySelectorAll("a > span")) {
+            let category_name = (category.text || "").trim();
+            if (category_name.endsWith(",")) {
+              category_name = category_name.slice(0, -1).trim();
+            }
+            if (category_name) tags["类型"].push(category_name);
+          }
         }
-        tags["类型"].push(category_name);
+        if (infos[2]) {
+          for (let tag of infos[2].querySelectorAll("a")) {
+            const tagText = (tag.text || "").replace("\n", "").replaceAll(" ", "").replace("#", "");
+            if (tagText) tags["标签"].push(tagText);
+          }
+        }
       }
-      for (let tag of infos[2].querySelectorAll("a")) {
-        tags["标签"].push(tag.text.replace("\n", "").replaceAll(" ", "").replace("#", ""));
+
+      const mangaEl = document.querySelector("#mangachapters");
+      const mangaId = mangaEl && mangaEl.attributes ? mangaEl.attributes["data-mid"] : null;
+      if (!mangaId) {
+        throw "无法获取漫画ID";
       }
-      const mangaId = document.querySelector("#mangachapters").attributes["data-mid"];
+
       const jsonRes = await Network.get(`${this.apiUrl}/manga/get?mid=${mangaId}&mode=all&t=${Date.now()}`, this.headers);
       const jsonData = JSON.parse(jsonRes.body);
       const chapters = {};
-      for (let ch of jsonData["data"]["chapters"]) {
-        chapters[`${mangaId}@${ch["id"]}`] = ch["attributes"]["title"];
+      if (jsonData["data"] && jsonData["data"]["chapters"]) {
+        for (let ch of jsonData["data"]["chapters"]) {
+          if (ch["id"] != null && ch["attributes"] && ch["attributes"]["title"] != null) {
+            chapters[`${mangaId}@${ch["id"]}`] = ch["attributes"]["title"];
+          }
+        }
       }
       const recommend = [];
       for (let item of document.querySelectorAll("div.cardlist > div.pb-2")) {
-        recommend.push(new Comic({
-          id: item.querySelector("a").attributes["href"],
-          title: item.querySelector("h3").text,
-          cover: item.querySelector("img").attributes["src"]
-        }));
+        const recLink = item.querySelector("a");
+        const recTitle = item.querySelector("h3");
+        const recImg = item.querySelector("img");
+        if (recLink && recTitle && recImg && recLink.attributes["href"] && recImg.attributes["src"]) {
+          recommend.push(new Comic({
+            id: recLink.attributes["href"],
+            title: recTitle.text,
+            cover: recImg.attributes["src"]
+          }));
+        }
       }
       return new ComicDetails({
         title: title,
@@ -313,15 +458,31 @@ class Goda extends ComicSource {
     },
 
     loadEp: async (comicId, epId) => {
+      if (!epId || !epId.includes("@")) {
+        throw "无效的章节ID";
+      }
       const ids = epId.split("@");
-      const res = await Network.get(`${this.apiUrl}/chapter/getinfo?m=${ids[0]}&c=${ids[1]}`, this.headers);
+      const res = await Network.get(`${this.apiUrl}/v2/chapter/getinfo?m=${ids[0]}&c=${ids[1]}`, this.headers);
       if (res.status !== 200) {
         throw `Invalid status code: ${res.status}`;
       }
       const jsonData = JSON.parse(res.body);
+      const imagesRaw = jsonData["data"]["info"]["images"]["images"];
+
+      let imagesList;
+      if (typeof imagesRaw === "string") {
+        // v2 API: obfuscated string - decode it back to JSON array
+        imagesList = decodeChapterImages(imagesRaw);
+      } else {
+        // v1 API (backward compatibility): array of {url: "...", order: N}
+        imagesList = imagesRaw;
+      }
+
       const images = [];
-      for (let i of jsonData["data"]["info"]["images"]["images"]) {
-        images.push(this.imageUrl + i["url"]);
+      for (let i of imagesList) {
+        if (i && i["url"]) {
+          images.push(this.imageUrl + i["url"]);
+        }
       }
       return { images };
     },

--- a/index.json
+++ b/index.json
@@ -144,7 +144,7 @@
         "name": "GoDa漫画",
         "fileName": "goda.js",
         "key": "goda",
-        "version": "1.0.0"
+        "version": "1.2.0"
     },
     {
         "name": "18漫画",

--- a/index.json
+++ b/index.json
@@ -144,7 +144,7 @@
         "name": "GoDa漫画",
         "fileName": "goda.js",
         "key": "goda",
-        "version": "1.2.0"
+        "version": "1.2.1"
     },
     {
         "name": "18漫画",


### PR DESCRIPTION
- 将 /api/chapter/getinfo 切换至 /api/v2/chapter/getinfo，修复HTTP 410
- 移植 keiyoushi/extensions-source PR#16898 的 ChapterImageDecoder 解码器
- 用纯JS实现 base64 解码，替代 atob()（兼容venera运行时）
- 在 parseComics/loadInfo/loadEp 中添加空安全保护
- 移除 console.warn 调试残留
- API域名从api-get-v3.mgsearcher.com更改为v2.apikk.top
- 图片域名改为c-nd3-1.6wm.top（修复有一些图片不加载）