### PR TITLE
修复少年ジャンプ＋和カドコミ

### DIFF
--- a/.github/workflows/pr-source-validate.yml
+++ b/.github/workflows/pr-source-validate.yml
@@ -23,16 +23,16 @@ jobs:
       - name: Fetch base branch
         run: git fetch origin "${{ github.base_ref }}"
 
-      - name: Clone latest venerax_cli
-        run: git clone --depth 1 https://github.com/venerax-app/venerax_cli.git /tmp/venerax_cli
+      - name: Clone latest venera_cli
+        run: git clone --depth 1 https://github.com/venera-app/venera_cli.git /tmp/venera_cli
 
-      - name: Get venerax_cli dependencies
-        working-directory: /tmp/venerax_cli
+      - name: Get venera_cli dependencies
+        working-directory: /tmp/venera_cli
         run: dart pub get
 
-      - name: Build venerax_cli
-        working-directory: /tmp/venerax_cli
-        run: dart build cli --target bin/venerax.dart --output /tmp/venerax
+      - name: Build venera_cli
+        working-directory: /tmp/venera_cli
+        run: dart build cli --target bin/venera.dart --output /tmp/venera
 
       - name: Collect changed config files
         id: changed-configs
@@ -46,7 +46,7 @@ jobs:
         run: |
           while IFS= read -r file; do
             [ -n "$file" ] || continue
-            /tmp/venerax/bundle/bin/venerax source validate "$file"
+            /tmp/venera/bundle/bin/venera source validate "$file"
           done < /tmp/changed-configs.txt
 
       - name: No changed config files

--- a/.github/workflows/pr-source-validate.yml
+++ b/.github/workflows/pr-source-validate.yml
@@ -23,16 +23,16 @@ jobs:
       - name: Fetch base branch
         run: git fetch origin "${{ github.base_ref }}"
 
-      - name: Clone latest venera_cli
-        run: git clone --depth 1 https://github.com/venera-app/venera_cli.git /tmp/venera_cli
+      - name: Clone latest venerax_cli
+        run: git clone --depth 1 https://github.com/venerax-app/venerax_cli.git /tmp/venerax_cli
 
-      - name: Get venera_cli dependencies
-        working-directory: /tmp/venera_cli
+      - name: Get venerax_cli dependencies
+        working-directory: /tmp/venerax_cli
         run: dart pub get
 
-      - name: Build venera_cli
-        working-directory: /tmp/venera_cli
-        run: dart build cli --target bin/venera.dart --output /tmp/venera
+      - name: Build venerax_cli
+        working-directory: /tmp/venerax_cli
+        run: dart build cli --target bin/venerax.dart --output /tmp/venerax
 
       - name: Collect changed config files
         id: changed-configs
@@ -46,7 +46,7 @@ jobs:
         run: |
           while IFS= read -r file; do
             [ -n "$file" ] || continue
-            /tmp/venera/bundle/bin/venera source validate "$file"
+            /tmp/venerax/bundle/bin/venerax source validate "$file"
           done < /tmp/changed-configs.txt
 
       - name: No changed config files

--- a/comic_walker.js
+++ b/comic_walker.js
@@ -75,14 +75,15 @@ class ComicWalker extends ComicSource {
     return response;
   }
 
+  // 修复：将 response 改为 resp，并正确解析 JSON
   async init() {
     const itunes_api = "https://itunes.apple.com/lookup?bundleId=jp.co.bookwalker.cwapp.ios&country=jp";
 
     const resp = await Network.get(itunes_api);
 
     if (resp.status == 200) {
-      response = JSON.parse(resp.body);
-      this.latestVersion = response.version;
+      const data = JSON.parse(resp.body);
+      this.latestVersion = data.version;
     }
 
     await this.refreshToken();
@@ -141,7 +142,6 @@ class ComicWalker extends ComicSource {
             }),
         );
         result["新連載"] = newSerialization;
-
 
         return result;
       },

--- a/comic_walker.js
+++ b/comic_walker.js
@@ -1,23 +1,28 @@
 class ComicWalker extends ComicSource {
   name = "カドコミ";
   key = "comic_walker";
-  version = "1.0.0";
+  version = "1.1.0";
   minAppVersion = "1.6.0";
   url =
     "https://cdn.jsdelivr.net/gh/venera-app/venera-configs@main/comic_walker.js";
 
   api_key = "ytBrdQ2ZYdRQguqEusVLxQVUgakNnVht";
 
-  latestVersion = "1.4.13";
+  latestVersion = "1.5.0";
 
   api_base = "https://mobileapp.comic-walker.com";
+
+  // 根级方法避免框架报错
+  onTagSuggestionSelected() {}
 
   get headers() {
     const headers = {
       "X-API-Environment-Key": this.api_key,
-      "User-Agent": `BookWalkerApp/${this.latestVersion} (Android 13)`,
+      // 改进 User-Agent 格式，更贴近真实应用
+      "User-Agent": `BookWalkerApp/${this.latestVersion} (Android 13; en_US; Phone; com.bookwalker)`,
       "Host": "mobileapp.comic-walker.com",
-      "Content-Type": "application/json"
+      "Content-Type": "application/json",
+      "Accept": "application/json"
     };
     const token = this.loadData("token");
     if (token) {
@@ -31,62 +36,94 @@ class ComicWalker extends ComicSource {
       `${this.api_base}/v1/users`,
       this.headers,
       "POST",
+      {}
     );
 
-    this.saveData("token", res.resources.access_token);
-    return res.resources.access_token;
+    if (res && res.resources && res.resources.access_token) {
+      this.saveData("token", res.resources.access_token);
+      return res.resources.access_token;
+    }
+    throw new Error("Failed to get access token");
   }
 
   async request(url, headers, method = "GET", data) {
     let response;
-    if (method === "GET") {
-      response = await Network.get(url, headers);
-    } else if (method === "POST") {
-      response = await Network.post(url, headers, data);
-    } else {
-      throw new Error(`Unsupported method: ${method}`);
-    }
-    if (
-      response.status === 204
-    ) {
-      return response;
-    }
-    response = JSON.parse(response.body);
-    if (
-      response.code === "invalid_request_parameter" ||
-      response.code === "free_daily_reward_quota_exceeded" ||
-      response.code === "unauthorized"
-    ) {
-      await this.refreshToken();
+    try {
       if (method === "GET") {
-        response = await Network.get(url, this.headers);
+        response = await Network.get(url, headers);
       } else if (method === "POST") {
-        response = await Network.post(url, this.headers, data);
+        response = await Network.post(url, headers, data);
       } else {
         throw new Error(`Unsupported method: ${method}`);
       }
-      if (
-        response.status === 204
-      ) {
-        return response;
-      }
-      response = JSON.parse(response.body);
+    } catch (e) {
+      throw e;
     }
-    return response;
+
+    // 处理非 2xx 或 204 状态码，不尝试解析 JSON
+    if (response.status !== 200 && response.status !== 204) {
+      throw new Error(`HTTP ${response.status}: ${response.body || "No body"}`);
+    }
+
+    if (response.status === 204) {
+      return response;
+    }
+
+    let json;
+    try {
+      json = JSON.parse(response.body);
+    } catch (e) {
+      throw new Error(`Invalid JSON response: ${response.body.substring(0, 100)}`);
+    }
+
+    // 处理业务错误码
+    if (
+      json.code === "invalid_request_parameter" ||
+      json.code === "free_daily_reward_quota_exceeded" ||
+      json.code === "unauthorized"
+    ) {
+      await this.refreshToken();
+      const newHeaders = { ...headers, ...this.headers };
+      let retryResponse;
+      if (method === "GET") {
+        retryResponse = await Network.get(url, newHeaders);
+      } else if (method === "POST") {
+        retryResponse = await Network.post(url, newHeaders, data);
+      }
+      if (retryResponse.status !== 200 && retryResponse.status !== 204) {
+        throw new Error(`Retry failed with status ${retryResponse.status}`);
+      }
+      if (retryResponse.status === 204) return retryResponse;
+      try {
+        json = JSON.parse(retryResponse.body);
+      } catch (e) {
+        throw new Error(`Retry invalid JSON: ${retryResponse.body.substring(0, 100)}`);
+      }
+    }
+    return json;
   }
 
-  // 修复：将 response 改为 resp，并正确解析 JSON
   async init() {
     const itunes_api = "https://itunes.apple.com/lookup?bundleId=jp.co.bookwalker.cwapp.ios&country=jp";
 
-    const resp = await Network.get(itunes_api);
-
-    if (resp.status == 200) {
-      const data = JSON.parse(resp.body);
-      this.latestVersion = data.version;
+    try {
+      const resp = await Network.get(itunes_api);
+      if (resp.status == 200) {
+        const data = JSON.parse(resp.body);
+        if (data.results && data.results.length > 0) {
+          this.latestVersion = data.results[0].version;
+        }
+      }
+    } catch (e) {
+      console.warn("Failed to fetch latest version, using default:", this.latestVersion);
     }
 
-    await this.refreshToken();
+    // 尝试刷新 token，失败不阻断初始化
+    try {
+      await this.refreshToken();
+    } catch (e) {
+      console.warn("Failed to refresh token during init:", e.message);
+    }
   }
 
   explore = [
@@ -182,6 +219,8 @@ class ComicWalker extends ComicSource {
   };
 
   comic = {
+    onTagSuggestionSelected() {},
+
     loadInfo: async (id) => {
       const res = await this.request(
         `${this.api_base}/v2/screens/comics/${id}`,
@@ -226,10 +265,10 @@ class ComicWalker extends ComicSource {
       for (const ep of episodes.resources) {
         let canRent = false;
         const plans = (ep.plans || []).filter((plan) =>
-      plan.type !== "paid"
+          plan.type !== "paid"
         );
         if (Array.isArray(plans) && plans.length > 0) {
-      canRent = true;
+          canRent = true;
         }
         const title = canRent ? ep.title : `❌ ${ep.title}`;
         chapters.set(ep.id, title);
@@ -254,7 +293,6 @@ class ComicWalker extends ComicSource {
         this.headers,
       );
       const plans = (detail.plans || []).filter((plan) =>
-        // plan.type !== "daily_video_free" &&
         plan.type !== "paid"
       );
       if (
@@ -333,7 +371,7 @@ class ComicWalker extends ComicSource {
           var key = [${keyArray.join(',')}];
           var view = new Uint8Array(buffer);
           for (var i = 0; i < view.length; i++) {
-        view[i] ^= key[i % key.length];
+            view[i] ^= key[i % key.length];
           }
           return buffer;
         }
@@ -342,7 +380,7 @@ class ComicWalker extends ComicSource {
       return {
         url: cleanUrl,
         headers: this.headers,
-        onResponse: async (buffer)  => {
+        onResponse: async (buffer) => {
           return await compute(onResponseScript, buffer);
         }
       };

--- a/shonen_jump_plus.js
+++ b/shonen_jump_plus.js
@@ -1,7 +1,7 @@
 class ShonenJumpPlus extends ComicSource {
   name = "少年ジャンプ＋";
   key = "shonen_jump_plus";
-  version = "1.1.1";
+  version = "1.1.2"; // 升级源版本号
   minAppVersion = "1.2.1";
   url =
     "https://cdn.jsdelivr.net/gh/venera-app/venera-configs@main/shonen_jump_plus.js";
@@ -10,36 +10,49 @@ class ShonenJumpPlus extends ComicSource {
   bearerToken = null;
   userAccountId = null;
   tokenExpiry = 0;
-  latestVersion = "4.0.24";
+  latestVersion = "4.3.0"; // 备用版本（建议定期更新）
+  _retryCount = 0; // 重试计数器
 
   get headers() {
     return {
-      "Origin": "https://shonenjumpplus.com",
-      "Referer": "https://shonenjumpplus.com/",
+      Origin: "https://shonenjumpplus.com",
+      Referer: "https://shonenjumpplus.com/",
       "X-Giga-Device-Id": this.deviceId,
       "User-Agent": `ShonenJumpPlus-Android/${this.latestVersion}`,
     };
   }
 
   apiBase = `https://shonenjumpplus.com/api/v1`;
+
   generateDeviceId() {
     let result = "";
     const chars = "0123456789abcdef";
     for (let i = 0; i < 16; i++) {
-      result += chars[randomInt(0, chars.length - 1)];
+      result += chars[Math.floor(Math.random() * chars.length)];
     }
     return result;
   }
 
+  // 初始化：获取最新版本号
   async init() {
-    const url = "https://apps.apple.com/jp/app/id875750302";
-
-    const resp = await Network.get(url);
-
-    const match = resp.body.match(/whats-new__latest__version">[^<]*?([\d.]+)</);
-
-    if (match && match[1]) {
-      this.latestVersion = match[1];
+    try {
+      // 使用 iTunes Lookup API
+      const url = "https://itunes.apple.com/jp/lookup?id=875750302";
+      const resp = await Network.get(url);
+      if (resp.status !== 200) throw new Error(`HTTP ${resp.status}`);
+      const data = JSON.parse(resp.body);
+      if (data.results && data.results.length > 0) {
+        const version = data.results[0].version;
+        if (version) {
+          this.latestVersion = version;
+          console.log(`[ShonenJumpPlus] 获取到最新版本: ${version}`);
+          return;
+        }
+      }
+      throw new Error("无法从 iTunes 解析版本号");
+    } catch (e) {
+      console.warn("[ShonenJumpPlus] 获取版本失败，使用备用版本", e);
+      // 备用版本保持不变（已初始化）
     }
   }
 
@@ -57,36 +70,41 @@ class ShonenJumpPlus extends ComicSource {
         }
 
         const sections = response.data.homeSections;
-        const dailyRankingSection = sections.find((section) =>
-          section.__typename === "DailyRankingSection"
+        const dailyRankingSection = sections.find(
+          (section) => section.__typename === "DailyRankingSection",
         );
 
         if (!dailyRankingSection || !dailyRankingSection.dailyRankings) {
           throw "Cannot fetch daily ranking data";
         }
 
-        const dailyRanking = dailyRankingSection.dailyRankings.find((ranking) =>
-          ranking.ranking && ranking.ranking.__typename === "DailyRanking"
+        const dailyRanking = dailyRankingSection.dailyRankings.find(
+          (ranking) =>
+            ranking.ranking && ranking.ranking.__typename === "DailyRanking",
         );
 
         if (
-          !dailyRanking || !dailyRanking.ranking ||
-          !dailyRanking.ranking.items || !dailyRanking.ranking.items.edges
+          !dailyRanking ||
+          !dailyRanking.ranking ||
+          !dailyRanking.ranking.items ||
+          !dailyRanking.ranking.items.edges
         ) {
           throw "Cannot fetch ranking data structure";
         }
 
-        const rankingItems = dailyRanking.ranking.items.edges.map((edge) =>
-          edge.node
-        ).filter((node) =>
-          node.__typename === "DailyRankingValidItem" && node.product
-        );
+        const rankingItems = dailyRanking.ranking.items.edges
+          .map((edge) => edge.node)
+          .filter(
+            (node) =>
+              node.__typename === "DailyRankingValidItem" && node.product,
+          );
 
         function parseComic(item) {
           const series = item.product.series;
           if (!series) return null;
 
-          const cover = series.squareThumbnailUriTemplate ||
+          const cover =
+            series.squareThumbnailUriTemplate ||
             series.horizontalThumbnailUriTemplate;
 
           return {
@@ -102,9 +120,9 @@ class ShonenJumpPlus extends ComicSource {
           };
         }
 
-        const comics = rankingItems.map(parseComic).filter((comic) =>
-          comic !== null
-        );
+        const comics = rankingItems
+          .map(parseComic)
+          .filter((comic) => comic !== null);
 
         const result = {};
         result["Daily Ranking"] = comics;
@@ -127,34 +145,36 @@ class ShonenJumpPlus extends ComicSource {
       const edges = response?.data?.search?.edges || [];
       const pageInfo = response?.data?.search?.pageInfo || {};
 
-      const comics = edges.map(({ node }) => {
-        const authors = (node.author?.name || "").split(/\s*\/\s*/).filter(
-          Boolean,
-        );
-        const cover = node.latestIssue?.thumbnailUriTemplate ||
-          node.thumbnailUriTemplate;
-        if (node.__typename === "Series") {
-          return new Comic({
-            id: node.databaseId,
-            title: node.title || "",
-            cover: this.replaceCoverUrl(cover),
-            description: node.description || "",
-            tags: authors,
-          });
-        }
-        if (node.__typename === "MagazineLabel") {
-          return new Comic({
-            id: node.databaseId,
-            title: node.title || "",
-            cover: this.replaceCoverUrl(cover),
-          });
-        }
-        return null;
-      }).filter(Boolean);
+      const comics = edges
+        .map(({ node }) => {
+          const authors = (node.author?.name || "")
+            .split(/\s*\/\s*/)
+            .filter(Boolean);
+          const cover =
+            node.latestIssue?.thumbnailUriTemplate || node.thumbnailUriTemplate;
+          if (node.__typename === "Series") {
+            return new Comic({
+              id: node.databaseId,
+              title: node.title || "",
+              cover: this.replaceCoverUrl(cover),
+              description: node.description || "",
+              tags: authors,
+            });
+          }
+          if (node.__typename === "MagazineLabel") {
+            return new Comic({
+              id: node.databaseId,
+              title: node.title || "",
+              cover: this.replaceCoverUrl(cover),
+            });
+          }
+          return null;
+        })
+        .filter(Boolean);
 
       return {
         comics,
-        maxPage: pageInfo.hasNextPage ? (page || 1) + 1 : (page || 1),
+        maxPage: pageInfo.hasNextPage ? (page || 1) + 1 : page || 1,
         endCursor: pageInfo.endCursor,
       };
     },
@@ -180,13 +200,14 @@ class ShonenJumpPlus extends ComicSource {
         { chapters: {}, latestPublishAt: "" },
       );
 
-      const maxDate = latestPublishAt > seriesData.openAt
-        ? latestPublishAt
-        : seriesData.openAt;
+      const maxDate =
+        latestPublishAt > seriesData.openAt
+          ? latestPublishAt
+          : seriesData.openAt;
       const updateDate = new Date(new Date(maxDate) - 60 * 60 * 1000);
-      const authors = (seriesData.author?.name || "").split(/\s*\/\s*/).filter(
-        Boolean,
-      );
+      const authors = (seriesData.author?.name || "")
+        .split(/\s*\/\s*/)
+        .filter(Boolean);
 
       return new ComicDetails({
         title: seriesData.title || "",
@@ -194,8 +215,8 @@ class ShonenJumpPlus extends ComicSource {
         cover: this.replaceCoverUrl(seriesData.thumbnailUriTemplate),
         description: seriesData.description || "",
         tags: {
-          "Author": authors,
-          "Update": [updateDate.toISOString().slice(0, 10)],
+          Author: authors,
+          Update: [updateDate.toISOString().slice(0, 10)],
         },
         url: `https://shonenjumpplus.com/app/episode/${seriesData.publisherId}`,
         chapters,
@@ -235,32 +256,53 @@ class ShonenJumpPlus extends ComicSource {
     },
   };
 
+  // ---------- 辅助方法 ----------
   async ensureAuth() {
     if (!this.bearerToken || Date.now() > this.tokenExpiry) {
       await this.fetchBearerToken();
     }
   }
 
-  async graphqlRequest(operationName, variables) {
-    const payload = {
-      operationName,
-      variables,
-      query: GraphQLQueries[operationName],
-    };
-    const response = await Network.post(
-      `${this.apiBase}/graphql?opname=${operationName}`,
-      {
-        ...this.headers,
-        "Authorization": `Bearer ${this.bearerToken}`,
-        "Accept": "application/json",
-        "X-APOLLO-OPERATION-NAME": operationName,
-        "Content-Type": "application/json",
-      },
-      JSON.stringify(payload),
-    );
+  // 封装 graphql 请求，自动处理 410 并重试
+  async graphqlRequest(operationName, variables, retry = true) {
+    try {
+      const payload = {
+        operationName,
+        variables,
+        query: GraphQLQueries[operationName],
+      };
+      const response = await Network.post(
+        `${this.apiBase}/graphql?opname=${operationName}`,
+        {
+          ...this.headers,
+          Authorization: `Bearer ${this.bearerToken}`,
+          Accept: "application/json",
+          "X-APOLLO-OPERATION-NAME": operationName,
+          "Content-Type": "application/json",
+        },
+        JSON.stringify(payload),
+      );
 
-    if (response.status !== 200) throw `Invalid status: ${response.status}`;
-    return JSON.parse(response.body);
+      if (response.status === 410) {
+        if (retry && this._retryCount < 3) {
+          this._retryCount++;
+          console.warn("[ShonenJumpPlus] 收到 410，尝试更新版本并重试");
+          await this.init(); // 重新获取版本
+          // 重新获取 token（因为可能失效）
+          await this.fetchBearerToken();
+          // 重试请求（不再次重试，防止死循环）
+          return this.graphqlRequest(operationName, variables, false);
+        } else {
+          throw new Error(`GraphQL 请求失败，状态码 410，版本可能需要手动更新`);
+        }
+      }
+
+      if (response.status !== 200) throw `Invalid status: ${response.status}`;
+      return JSON.parse(response.body);
+    } catch (e) {
+      console.error("[ShonenJumpPlus] graphqlRequest 异常:", e);
+      throw e;
+    }
   }
 
   normalizeEpisodeId(epId) {
@@ -272,24 +314,45 @@ class ShonenJumpPlus extends ComicSource {
   }
 
   replaceCoverUrl(url) {
-    return (url || "").replace("{height}", "1500").replace(
-      "{width}",
-      "1500",
-    ) || "";
+    return (
+      (url || "").replace("{height}", "1500").replace("{width}", "1500") || ""
+    );
   }
 
-  async fetchBearerToken() {
-    const response = await Network.post(
-      `${this.apiBase}/user_account/access_token`,
-      this.headers,
-      "",
-    );
-    const { access_token, user_account_id } = JSON.parse(
-      response.body,
-    );
-    this.bearerToken = access_token;
-    this.userAccountId = user_account_id;
-    this.tokenExpiry = Date.now() + 3600000;
+  // 获取 bearer token，处理 410
+  async fetchBearerToken(retry = true) {
+    try {
+      const response = await Network.post(
+        `${this.apiBase}/user_account/access_token`,
+        this.headers,
+        "",
+      );
+
+      if (response.status === 410) {
+        if (retry && this._retryCount < 3) {
+          this._retryCount++;
+          console.warn("[ShonenJumpPlus] token 请求收到 410，尝试更新版本并重试");
+          await this.init();
+          // 重新请求（不再重试）
+          return this.fetchBearerToken(false);
+        } else {
+          throw new Error("获取 access_token 失败，状态码 410，版本过旧");
+        }
+      }
+
+      if (response.status !== 200) {
+        throw new Error(`获取 access_token 失败，状态码 ${response.status}`);
+      }
+
+      const { access_token, user_account_id } = JSON.parse(response.body);
+      this.bearerToken = access_token;
+      this.userAccountId = user_account_id;
+      this.tokenExpiry = Date.now() + 3600000;
+      this._retryCount = 0; // 重置重试计数
+    } catch (e) {
+      console.error("[ShonenJumpPlus] fetchBearerToken 异常:", e);
+      throw e;
+    }
   }
 
   async fetchSeriesDetail(id) {
@@ -298,12 +361,14 @@ class ShonenJumpPlus extends ComicSource {
   }
 
   async fetchEpisodes(id) {
-    const response = await this.graphqlRequest(
-      "SeriesDetailEpisodeList",
-      { id, episodeOffset: 0, episodeFirst: 1500, episodeSort: "NUMBER_ASC" },
-    );
+    const response = await this.graphqlRequest("SeriesDetailEpisodeList", {
+      id,
+      episodeOffset: 0,
+      episodeFirst: 1500,
+      episodeSort: "NUMBER_ASC",
+    });
     const episodes = (response?.data?.series?.episodes?.edges || []).map(
-      (edge) => edge.node
+      (edge) => edge.node,
     );
     return episodes;
   }
@@ -317,21 +382,25 @@ class ShonenJumpPlus extends ComicSource {
   }
 
   isEpisodeAccessible({ purchaseInfo }) {
-    return purchaseInfo?.isFree || purchaseInfo?.hasPurchased ||
-      purchaseInfo?.hasRented;
+    return (
+      purchaseInfo?.isFree ||
+      purchaseInfo?.hasPurchased ||
+      purchaseInfo?.hasRented
+    );
   }
 
   async handleEpisodePurchase(episodeData) {
     const { id, purchaseInfo } = episodeData;
-    const { purchasableViaOnetimeFree, rentable, unitPrice } = purchaseInfo ||
-      {};
+    const { purchasableViaOnetimeFree, rentable, unitPrice } =
+      purchaseInfo || {};
 
     if (purchasableViaOnetimeFree) await this.consumeOnetimeFree(id);
     if (rentable) await this.rentChapter(id, unitPrice);
   }
 
   buildImageUrls({ pageImages, pageImageToken }) {
-    const validImages = pageImages.edges.flatMap((edge) => edge.node?.src)
+    const validImages = pageImages.edges
+      .flatMap((edge) => edge.node?.src)
       .filter(Boolean);
     return {
       images: validImages.map((url) => `${url}?token=${pageImageToken}`),
@@ -382,8 +451,9 @@ class ShonenJumpPlus extends ComicSource {
   }
 }
 
+// GraphQL 查询（保持不变）
 const GraphQLQueries = {
-  "SearchResult": `query SearchResult($after: String, $keyword: String!) {
+  SearchResult: `query SearchResult($after: String, $keyword: String!) {
         search(after: $after, first: 50, keyword: $keyword, types: [SERIES,MAGAZINE_LABEL]) {
             pageInfo { hasNextPage endCursor }
             edges {
@@ -395,7 +465,7 @@ const GraphQLQueries = {
             }
         }
     }`,
-  "SeriesDetail": `query SeriesDetail($id: String!) {
+  SeriesDetail: `query SeriesDetail($id: String!) {
         series(databaseId: $id) {
             id databaseId title thumbnailUriTemplate
             author { name }
@@ -405,16 +475,14 @@ const GraphQLQueries = {
             publisherId
         }
     }`,
-  "SeriesDetailEpisodeList":
-    `query SeriesDetailEpisodeList($id: String!, $episodeOffset: Int, $episodeFirst: Int, $episodeSort: ReadableProductSorting) {
+  SeriesDetailEpisodeList: `query SeriesDetailEpisodeList($id: String!, $episodeOffset: Int, $episodeFirst: Int, $episodeSort: ReadableProductSorting) {
         series(databaseId: $id) {
             episodes: readableProducts(types: [EPISODE], first: $episodeFirst, offset: $episodeOffset, sort: $episodeSort) {
                 edges { node { databaseId title publishedAt } }
             }
         }
     }`,
-  "EpisodeViewerConditionallyCacheable":
-    `query EpisodeViewerConditionallyCacheable($episodeID: String!) {
+  EpisodeViewerConditionallyCacheable: `query EpisodeViewerConditionallyCacheable($episodeID: String!) {
         episode(databaseId: $episodeID) {
             id pageImages { edges { node { src } } } pageImageToken
             purchaseInfo {
@@ -423,19 +491,18 @@ const GraphQLQueries = {
             }
         }
     }`,
-  "ConsumeOnetimeFree":
-    `mutation ConsumeOnetimeFree($input: ConsumeOnetimeFreeInput!) {
+  ConsumeOnetimeFree: `mutation ConsumeOnetimeFree($input: ConsumeOnetimeFreeInput!) {
         consumeOnetimeFree(input: $input) { isSuccess }
     }`,
-  "Rent": `mutation Rent($input: RentInput!) {
+  Rent: `mutation Rent($input: RentInput!) {
         rent(input: $input) {
             userAccount { databaseId }
         }
     }`,
-  "AddUserDevice": `mutation AddUserDevice($input: AddUserDeviceInput!) {
+  AddUserDevice: `mutation AddUserDevice($input: AddUserDeviceInput!) {
         addUserDevice(input: $input) { isSuccess }
     }`,
-  "HomeCacheable": `query HomeCacheable {
+  HomeCacheable: `query HomeCacheable {
     homeSections {
       __typename
       ...DailyRankingSection


### PR DESCRIPTION
经测试两漫画源可显示发现页内容和分类页内容，漫画可显示详情页并可阅读，两漫画源搜索正常

https://github.com/user-attachments/assets/ca81eac5-481f-4e4e-bd12-bae02034258b


https://github.com/user-attachments/assets/50289b34-d920-4fcd-b352-cc217bb80c94
